### PR TITLE
Optimize ancestors qs

### DIFF
--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -26,7 +26,7 @@ SECRET_KEY = '*c1rpjpo1o0@2yvbiiqg*=xln677qf6!2*ixk2a&5pcf5drno&'
 DEBUG = True
 
 ALLOWED_HOSTS = []
-
+INTERNAL_IPS = ['localhost', '127.0.0.1']
 
 # Application definition
 
@@ -41,9 +41,11 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'debug_toolbar',
 ]
 
 MIDDLEWARE = [
+    'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -6,3 +6,12 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^treewidget/', include('treewidget.urls')),
 ]
+
+from django.conf import settings
+from django.conf.urls import include, url
+
+if settings.DEBUG:
+    import debug_toolbar
+    urlpatterns = [
+        url(r'^__debug__/', include(debug_toolbar.urls)),
+    ] + urlpatterns

--- a/example/exampleapp/admin.py
+++ b/example/exampleapp/admin.py
@@ -19,7 +19,7 @@ class MpttAdmin(DraggableMPTTAdmin):
 
     def get_form(self, request, obj=None, **kwargs):
         form = super(MpttAdmin, self).get_form(request, obj=None, **kwargs)
-        form.base_fields['parent'].queryset = Mptt.objects.exclude(pk=1)
+        form.base_fields['parent'].queryset = Mptt.objects.exclude(pk=1)  # filtered qs
         return form
 
 
@@ -35,8 +35,15 @@ class TreebeardnsAdmin(TreeAdmin):
     form = movenodeform_factory(Treebeardns)
 
 
+class ExampleAdmin(admin.ModelAdmin):
+    def get_form(self, request, obj=None, **kwargs):
+        form = super(ExampleAdmin, self).get_form(request, obj=None, **kwargs)
+        form.base_fields['treebeardmp'].queryset = Treebeardmp.objects.exclude(pk=1)  # filtered qs
+        return form
+
+
 admin.site.register(Mptt, MpttAdmin)
 admin.site.register(Treebeardmp, TreebeardmpAdmin)
 admin.site.register(Treebeardal, TreebeardalAdmin)
 admin.site.register(Treebeardns, TreebeardnsAdmin)
-admin.site.register(Example, admin.ModelAdmin)
+admin.site.register(Example, ExampleAdmin)

--- a/example/exampleapp/models.py
+++ b/example/exampleapp/models.py
@@ -49,9 +49,12 @@ class Treebeardns(NS_Node):
 
 class Example(models.Model):
     mptt = TreeForeignKey(Mptt, on_delete=models.CASCADE)
-    treebeardmp = TreeForeignKey(Treebeardmp, on_delete=models.CASCADE, settings={'show_buttons': True})
-    treebeardal = TreeForeignKey(Treebeardal, on_delete=models.CASCADE, settings={'search': True, 'dnd': True, 'sort': True})
-    treebeardns = TreeForeignKey(Treebeardns, on_delete=models.CASCADE, settings={'dnd': True})
+    treebeardmp = TreeForeignKey(Treebeardmp, on_delete=models.CASCADE,
+                                 settings={'show_buttons': True, 'filtered': True})
+    treebeardal = TreeForeignKey(Treebeardal, on_delete=models.CASCADE,
+                                 settings={'search': True, 'dnd': True, 'sort': True})
+    treebeardns = TreeForeignKey(Treebeardns, on_delete=models.CASCADE,
+                                 settings={'dnd': True})
     mptt_many = TreeManyToManyField(Mptt, related_name='example_many',
                                     settings={'show_buttons': True, 'search': True, 'dnd': True})
     treebeardmp_many = TreeManyToManyField(Treebeardmp, related_name='example_many')

--- a/treewidget/formatters.py
+++ b/treewidget/formatters.py
@@ -26,22 +26,25 @@ class SelectFormatter(object):
 
     def render(self, queryset):
         """
-        Render method of tree data for jstree.
+        Render method of tree data for `jstree`.
         NOTE: `queryset` is a `tree.TreeQueryset` object.
-        To avoid expensive database lookups, the nodes and
-        their parents might be precached.
+        To avoid expensive database lookups, the parent pk
+        is accessible as `node.node._parent_pk`.
         """
         for node in queryset:
+            id = self.ID_TEMPLATE % (self.attr_name, node.pk)
+            parent = '#'
+            if node.node._parent_pk:
+                parent = self.ID_TEMPLATE % (self.attr_name, node.node._parent_pk)
             yield {
-                'id': self.ID_TEMPLATE % (self.attr_name, node.node.pk),
-                'parent': self.ID_TEMPLATE % (self.attr_name, node.parent.node.pk)
-                            if node.parent else '#',
+                'id': id,
+                'parent': parent,
                 'text': escape(force_text(node)),
                 'data': {
                     'sort': node.ordering if self.settings.get('sort') else []
                 },
                 'state': {
-                    'selected': True if str(node.node.pk) in self.selected else False,
-                    'disabled': True if node.node.pk in self.disabled else False
+                    'selected': True if str(node.pk) in self.selected else False,
+                    'disabled': True if node.pk in self.disabled else False
                 }
             }

--- a/treewidget/formatters.py
+++ b/treewidget/formatters.py
@@ -34,8 +34,13 @@ class SelectFormatter(object):
         for node in queryset:
             id = self.ID_TEMPLATE % (self.attr_name, node.pk)
             parent = '#'
+            #try:
             if node.node._parent_pk:
                 parent = self.ID_TEMPLATE % (self.attr_name, node.node._parent_pk)
+            #except AttributeError:
+            #    parent_obj = node.parent
+            #    if parent_obj:
+            #        parent = self.ID_TEMPLATE % (self.attr_name, parent_obj.node.pk)
             yield {
                 'id': id,
                 'parent': parent,

--- a/treewidget/formatters.py
+++ b/treewidget/formatters.py
@@ -24,23 +24,24 @@ class SelectFormatter(object):
         self.disabled = disabled
         self.settings = settings or {}
 
-    def render(self, node):
+    def render(self, queryset):
         """
-        Render method of a single node.
-        NOTE: `node` is a `tree.TreeNode` object.
-        Override the render method if you need other data in jstree.
-        :param node:
-        :return:
+        Render method of tree data for jstree.
+        NOTE: `queryset` is a `tree.TreeQueryset` object.
+        To avoid expensive database lookups, the nodes and
+        their parents might be precached.
         """
-        return {
-            'id': self.ID_TEMPLATE % (self.attr_name, node.node.pk),
-            'parent': self.ID_TEMPLATE % (self.attr_name, node.parent.node.pk) if node.parent else '#',
-            'text': escape(force_text(node)),
-            'data': {
-                'sort': node.ordering if self.settings.get('sort') else []
-            },
-            'state': {
-                'selected': True if str(node.node.pk) in self.selected else False,
-                'disabled': True if node.node.pk in self.disabled else False
+        for node in queryset:
+            yield {
+                'id': self.ID_TEMPLATE % (self.attr_name, node.node.pk),
+                'parent': self.ID_TEMPLATE % (self.attr_name, node.parent.node.pk)
+                            if node.parent else '#',
+                'text': escape(force_text(node)),
+                'data': {
+                    'sort': node.ordering if self.settings.get('sort') else []
+                },
+                'state': {
+                    'selected': True if str(node.node.pk) in self.selected else False,
+                    'disabled': True if node.node.pk in self.disabled else False
+                }
             }
-        }

--- a/treewidget/tree.py
+++ b/treewidget/tree.py
@@ -5,6 +5,9 @@ from django.utils.encoding import python_2_unicode_compatible
 
 try:
     from treebeard.models import Node as TreebeardNode
+    from treebeard.al_tree import AL_Node
+    from treebeard.ns_tree import NS_Node
+    from treebeard.mp_tree import MP_Node
     HAS_TREEBEARD = True
 except ImportError:
     HAS_TREEBEARD = False
@@ -29,6 +32,7 @@ TREEBEARD = {
         'descendants':  lambda node: force_treenode(node.get_descendants()),
         'level'     :   lambda node: node.get_depth(),
         'move'      :   lambda node: lambda target, pos: node.move(target, pos),
+        'is_root'   :   lambda node: node.is_root(),
     },
 }
 
@@ -46,6 +50,7 @@ MPTT = {
         'descendants':  lambda node: node.get_descendants(),
         'level'     :   lambda node: getattr(node, node.__class__._mptt_meta.level_attr, 0),
         'move'      :   lambda node: lambda target, pos: node.move_to(target, pos),
+        'is_root'   :   lambda node: node.is_root_node(),
     },
 }
 
@@ -57,10 +62,6 @@ class UnknownTreeImplementation(Exception):
 def get_treetype(model):
     """
     Return the function mapping of the real model tree implementation.
-
-    :raises UnknownTreeImplementation
-    :param model:
-    :return:
     """
     if HAS_TREEBEARD and issubclass(model, TreebeardNode):
         return TREEBEARD
@@ -81,7 +82,15 @@ class TreeQuerySet(object):
     """
     def __init__(self, qs, treetype=None):
         self.qs = qs
-        self.qs_it = iter(self.qs)
+        if isinstance(qs, TreeQuerySet):
+            self.qs = qs.qs
+            self.qs_it = qs.qs_it
+            self.cached = qs.cached
+            self.fill_cache = qs.fill_cache
+        else:
+            self.qs_it = iter(self.qs)
+            self.cached = []
+            self.fill_cache = True
         self.treetype = treetype or get_treetype(self.qs.model)
 
     def __getitem__(self, item):
@@ -96,9 +105,13 @@ class TreeQuerySet(object):
     def __next__(self):
         try:
             node = next(self.qs_it)
-            return TreeNode(node, self.qs.model, self.treetype)
+            if self.fill_cache:
+                node = TreeNode(node, self.qs.model, self.treetype)
+                self.cached.append(node)
+            return node
         except StopIteration:
-            self.qs_it = iter(self.qs)
+            self.qs_it = iter(self.cached)
+            self.fill_cache = False
             raise StopIteration
 
     def next(self):
@@ -135,6 +148,123 @@ class TreeQuerySet(object):
     def appmodel(self):
         return '%s.%s' % (self.qs.model._meta.app_label, self.qs.model._meta.model_name)
 
+    def get_ancestors(self):
+        # django mptt got a ready to go method
+        # has best runtime due to prefetch the parent attribute
+        if self.treetype == MPTT:
+            return TreeQuerySet(
+                self.qs.get_ancestors(include_self=True).select_related('parent'))
+
+        # for treebeard we have to get the parents ourself
+        # we also patch the result with a parent attribute
+        elif self.treetype == TREEBEARD:
+            if issubclass(self.qs.model, NS_Node):
+                from django.db.models import Q
+                pks = [node.pk for node in self.qs]
+                filters = Q(pk__in=set(pks))
+                for node in self.qs:
+                    if node.is_root():
+                        continue
+                    filters |= Q(tree_id=node.tree_id,
+                                 lft__lt=node.lft,
+                                 rgt__gt=node.rgt)
+
+                # patch parent attribute
+                qs = self.qs.model.objects.filter(filters)
+                nodes = [TreeNode(node) for node in qs]
+                for n in nodes:
+                    if n.is_root:
+                        continue
+                    for node in qs:
+                        if (node.tree_id == n.node.tree_id
+                                and node.lft <= n.node.lft
+                                and node.rgt >= n.node.rgt and node != n.node):
+                            n._parent = TreeNode(node)
+                # fake queryset with all nodes and parents in cache
+                qs = TreeQuerySet(qs)
+                qs.cached = nodes
+                qs.qs_it = iter(qs.cached)
+                qs.fill_cache = False
+                return qs
+
+            elif issubclass(self.qs.model, MP_Node):
+                from django.db.models import Q
+                pks = [node.pk for node in self.qs]
+                filters = Q(pk__in=set(pks))
+                for node in self.qs:
+                    if node.is_root():
+                        continue
+                    paths = [
+                        node.path[0:pos]
+                        for pos in range(0, len(node.path), node.steplen)[1:]
+                    ]
+                    filters |= Q(path__in=paths)
+
+                # patch parent attribute
+                qs = self.qs.model.objects.filter(filters)
+                nodes = [TreeNode(node) for node in qs]
+                for n in nodes:
+                    if n.is_root:
+                        continue
+                    depth = int(len(n.node.path) / n.node.steplen) - 1
+                    parentpath = n.node.path[0:depth * n.node.steplen]
+                    for node in qs:
+                        if node.path == parentpath:
+                            n._parent = TreeNode(node)
+                # fake queryset with all nodes and parents in cache
+                qs = TreeQuerySet(qs)
+                qs.cached = nodes
+                qs.qs_it = iter(qs.cached)
+                qs.fill_cache = False
+                return qs
+
+            elif issubclass(self.qs.model, AL_Node):
+                # almost like the generic fallback
+                # difference:
+                #   we have a parent attribute we can prefetch
+                #   to lower db interaction
+                nodes = self.qs.select_related('parent')
+                pks = set()
+                parents = set()
+                for node in nodes:
+                    pks.add(node.pk)
+                    if node.parent:
+                        parents.add(node.parent.pk)
+                missing = parents - pks
+
+                while missing:
+                    pks.update(parents)
+                    parents.clear()
+                    for node in self.qs.model.objects.filter(
+                            pk__in=missing).select_related('parent'):
+                        if node.parent:
+                            parents.add(node.parent.pk)
+                    missing = parents - pks
+
+                return TreeQuerySet(
+                    self.qs.model.objects.filter(
+                        pk__in=pks).select_related('parent'))
+
+        # fallback to generic implementation with worst runtime
+        # walks tree levels until all parents are known
+        pks = set()
+        parents = set()
+        for node in self:
+            pks.add(node.node.pk)
+            if not node.is_root:
+                parents.add(node.parent.node.pk)
+        missing = parents - pks
+
+        while missing:
+            pks.update(parents)
+            parents.clear()
+            for node in TreeQuerySet(self.qs.model.objects.filter(pk__in=missing)):
+                if node.parent:
+                    parents.add(node.parent.node.pk)
+            missing = parents - pks
+
+        return TreeQuerySet(self.qs.model.objects.filter(pk__in=pks))
+
 
 @python_2_unicode_compatible
 class TreeNode(object):
@@ -142,9 +272,9 @@ class TreeNode(object):
     Abstract tree node proxy for common tree attribute access.
     The real tree node can be accessed via the `node` attribute.
 
-    NOTE: Only typical tree node methods like get abstracted,
+    NOTE: Only typical tree node attributes get abstracted,
     if you need a specific value from a node, access it via `node`
-    (e.g. `obj.node.pk` for the pk value).
+    (e.g. `obj.node.some_field`).
     """
     def __init__(self, node, model=None, treetype=None):
         self.node = node
@@ -169,7 +299,11 @@ class TreeNode(object):
 
     @property
     def parent(self):
-        return self._get_real('parent')
+        try:
+            # hack for treebeard to avoid additional db lookups
+            return self._parent
+        except AttributeError:
+            return self._get_real('parent')
 
     @property
     def prev_sibling(self):
@@ -195,18 +329,21 @@ class TreeNode(object):
     def move(self):
         return self._get_real('move')
 
+    @property
+    def pk(self):
+        return self.node.pk
+
+    @property
+    def is_root(self):
+        return self._get_real('is_root')
+
 
 def force_treenode(it):
     """
     Helper function to enforce the content of a returned container type
     being TreeNode objects. This especially useful if a manager or queryet
     method returns a container with tree node objects.
-    :param it:
-    :return:
     """
-    def g(it):
-        for node in it:
-            yield TreeNode(node)
     if isinstance(it, TreeQuerySet):
         return it
-    return g(it)
+    return (TreeNode(node) for node in it)


### PR DESCRIPTION
Getting all ancestors in `get_drawable_queryset` led to an overhead of database queries. This is an optimized version, which can handle it with 2 additional queries (except treebeard's AL_Node). It is done by `get_ancestors_parent_annotated` which also annotates the parents as `_parent_pk` attribute to save further queries in formatter when looking up the parent pk.