### PR TITLE
fixes removed django.conf.urls.url import bug in django 4

### DIFF
--- a/treewidget/urls.py
+++ b/treewidget/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls import url
+try:
+    from django.conf.urls import url
+except ImportError:
+    # django 4 and up
+    from django.urls import re_path as url
 from treewidget.views import get_node, move_node
 
 urlpatterns = [


### PR DESCRIPTION
I was upgrading an app to django 4 and noticed that treewidget was throwing an ImportError - this change fixes that error.